### PR TITLE
ref  등록시에 자동으로 해당 샷에 자동으로 ref 링크되는 기능 추가함.

### DIFF
--- a/cmdfunc.go
+++ b/cmdfunc.go
@@ -305,10 +305,19 @@ func addOtherItemCmd(project, name, typ, platesize, scanname, scantimecodein, sc
 	if err != nil {
 		log.Fatal(err)
 	}
-	// src 라면 기존 plate에 소스 등록을 진행한다.
-	_, err = AddSource(session, project, name, "scantool", name+"_"+typ, platePath)
-	if err != nil {
-		log.Println(err)
+	// 만약 typ에 src 문자로 시작하면 소스로 판단하고 기존 item에 자동으로 소스 등록을 진행한다.
+	if strings.HasPrefix(typ, "src") {
+		_, err = AddSource(session, project, name, "scantool", name+"_"+typ, platePath)
+		if err != nil {
+			log.Println(err)
+		}
+	}
+	// 만약 typ이 ref 문자로 시작하면 레퍼런스로 판단하고 기존 item에 자동으로 레퍼런스 등록을 진행한다.
+	if strings.HasPrefix(typ, "ref") {
+		_, err = AddReference(session, project, name, "scantool", name+"_"+typ, platePath)
+		if err != nil {
+			log.Println(err)
+		}
 	}
 	// org1, left1 형태의 아이템이 처리되면 org, left 아이템의 .UseType을 추가해준다.
 	// 이 값은 썸네일을 업데이트하고, 아티스트가 재스캔 되었을 때 사용할 타입의 알람으로 사용된다.

--- a/db_item.go
+++ b/db_item.go
@@ -2888,7 +2888,7 @@ func RmComment(session *mgo.Session, project, name, userID, date string) (string
 }
 
 // AddSource 함수는 item에 소스링크를 추가한다.
-func AddSource(session *mgo.Session, project, name, userID, title, path string) (string, error) {
+func AddSource(session *mgo.Session, project, name, author, title, path string) (string, error) {
 	session.SetMode(mgo.Monotonic, true)
 	err := HasProject(session, project)
 	if err != nil {
@@ -2910,7 +2910,7 @@ func AddSource(session *mgo.Session, project, name, userID, title, path string) 
 	}
 	s := Source{}
 	s.Date = time.Now().Format(time.RFC3339)
-	s.Author = userID
+	s.Author = author
 	s.Title = title
 	s.Path = path
 	i.Sources = append(i.Sources, s)
@@ -2921,8 +2921,8 @@ func AddSource(session *mgo.Session, project, name, userID, title, path string) 
 	return id, nil
 }
 
-// AddReference 함수는 item에 소스링크를 추가한다.
-func AddReference(session *mgo.Session, project, name, userID, title, path string) (string, error) {
+// AddReference 함수는 item에 레퍼런스 링크를 추가한다.
+func AddReference(session *mgo.Session, project, name, author, title, path string) (string, error) {
 	session.SetMode(mgo.Monotonic, true)
 	err := HasProject(session, project)
 	if err != nil {
@@ -2939,7 +2939,7 @@ func AddReference(session *mgo.Session, project, name, userID, title, path strin
 	}
 	r := Source{}
 	r.Date = time.Now().Format(time.RFC3339)
-	r.Author = userID
+	r.Author = author
 	r.Title = title
 	r.Path = path
 	i.References = append(i.References, r)


### PR DESCRIPTION
Close: #1017 

과거에는 src로만 등록되는 버그가 있었습니다.
이제는 src 타입이면 src에, ref 타입이면 ref에 등록되도도록 버그를 수정했습니다.

![image](https://user-images.githubusercontent.com/1149996/98889164-c0253100-24dc-11eb-8d2e-d00831626874.png)
위 처럼 Cmd모드로 샷을 생성하기 위해서 터미널에서 타이핑했을 때

![image](https://user-images.githubusercontent.com/1149996/98889168-c3202180-24dc-11eb-8380-63c44163b380.png)
각각 source, reference에 맞게 자동으로 링크 및 등록됩니다.