### PR TITLE
review rm comment 리펙토링

### DIFF
--- a/documents/rest_review.md
+++ b/documents/rest_review.md
@@ -12,4 +12,4 @@
 | /api/setreviewstatus | 리뷰상태 변경 | id, status(wait, approve, comment) | `$ curl -X POST -d "id=5f87f82641a789486f3970d1&status=approve" -H "Authorization: Basic <Token>" https://csi.lazypic.org/api/setreviewstatus` |
 | /api/addreviewcomment | 리뷰 Comment 추가 | id, text, media, mediatitle | `$ curl -X POST -d "id=5f87f82641a789486f3970d1&text=수정사항&media=/show/drawing.jpg&mediatitle=참고이미지" -H "Authorization: Basic <Token>" https://csi.lazypic.org/api/addreviewcomment` |
 | /api/editreviewcomment | 리뷰 Comment 수정 | id, time, text | `$ curl -X POST -d "id=5f87f82641a789486f3970d1&status=" -H "Authorization: Basic <Token>" https://csi.lazypic.org/api/editreviewcomment` |
-| /api/rmreviewcomment | 리뷰 Comment 삭제 | id, time, (project), (name) | `$ curl -X POST -d "id=5f87f82641a789486f3970d1&time=2020-05-21T09:00:00%2B09:00" -H "Authorization: Basic <Token>" https://csi.lazypic.org/api/rmreviewcomment` |
+| /api/rmreviewcomment | 리뷰 Comment 삭제 | id, time | `$ curl -X POST -d "id=5f87f82641a789486f3970d1&time=2020-05-21T09:00:00%2B09:00" -H "Authorization: Basic <Token>" https://csi.lazypic.org/api/rmreviewcomment` |

--- a/restapiReview.go
+++ b/restapiReview.go
@@ -509,18 +509,23 @@ func handleAPIRmReviewComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	rcp.Time = reviewTime
-	reviewProject := r.FormValue("project")
-	if reviewProject == "" {
-		http.Error(w, "project를 설정해주세요", http.StatusBadRequest)
+
+	// ID를 이용해서 삭제할 리뷰아이템을 가져와 Project, Name, Text를 반환될 json에 설정합니다.
+	review, err := getReview(session, rcp.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	rcp.Project = reviewProject
-	reviewName := r.FormValue("name")
-	if reviewName == "" {
-		http.Error(w, "name을 설정해주세요", http.StatusBadRequest)
-		return
+	rcp.Project = review.Project
+	rcp.Name = review.Name
+	for _, t := range review.Comments {
+		if t.Date == reviewTime {
+			rcp.Text = t.Text
+			break
+		}
 	}
-	rcp.Name = reviewName
+
+	// 리뷰데이터를 삭제합니다.
 	err = RmReviewComment(session, rcp.ID, rcp.Time)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
리뷰데이터의 Comment를 지울때는 시간정보와 id만 필요합니다.
project, name은 내부 DB에서 불러와서 json 데이터에 설정할 수 있도록 구조를 바꾸었습니다.
내부 개발자와 대화도중 필수값 옵션을 더 줄이는 방법에 대해 논의를 통해서 이 이슈가 진행되었습니다.

Close: #1069 