### PR TITLE
디테일 페이지가 보이지 않는 버그 수정.

### DIFF
--- a/assets/template/detailItem.html
+++ b/assets/template/detailItem.html
@@ -319,7 +319,6 @@
 								hold={{$.SearchOption.Hold}}&
 								out={{$.SearchOption.Out}}&
 								none={{$.SearchOption.None}}&
-								template={{$.SearchOption.Template}}&
 								searchbartemplate={{$.SearchOption.SearchbarTemplate}}&
 								truestatus={{Join $.AllStatusIDs "," }}&
 								task={{$.SearchOption.Task}}" class="badge badge-outline-darkmode">{{.}}</a>
@@ -343,7 +342,6 @@
 							hold={{$.SearchOption.Hold}}&
 							out={{$.SearchOption.Out}}&
 							none={{$.SearchOption.None}}&
-							template={{$.SearchOption.Template}}&
 							searchbartemplate={{$.SearchOption.SearchbarTemplate}}&
 							truestatus={{Join $.AllStatusIDs "," }}&
 							task={{$.SearchOption.Task}}" class="badge badge-outline-darkmode">{{.}}</a>


### PR DESCRIPTION
Close: #1149 

SearchOption에서 Template이 사라졌지만 디테일 페이지에서 사용중이었다.