### PR TITLE
edit review item status 가 작동되도록 하기.

### DIFF
--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -1232,6 +1232,7 @@ function setEditReviewModal(id) {
         document.getElementById("modal-editreview-task").value = data.task;
         document.getElementById("modal-editreview-name").value = data.name;
         document.getElementById("modal-editreview-stage").value = data.stage;
+        document.getElementById("modal-editreview-itemstatus").value = data.itemstatus;
         document.getElementById("modal-editreview-createtime").value = data.createtime;
         document.getElementById("modal-editreview-path").value = data.path;
         document.getElementById("modal-editreview-mainversion").value = data.mainversion;
@@ -4670,6 +4671,32 @@ function setReviewStage(stage) {
             itemStage.setAttribute("class","ml-1 badge badge-stage-"+data.stage)
             // 현재 띄워진 화면의 우측하단의 Stage 상태를 변경한다.
             document.getElementById("current-review-stage").value = data.stage
+        },
+        error: function(request,status,error){
+            alert("code:"+request.status+"\n"+"status:"+status+"\n"+"msg:"+request.responseText+"\n"+"error:"+error);
+        }
+    });
+}
+
+function setReviewItemStatus(itemstatus) {
+    $.ajax({
+        url: "/api/setreviewitemstatus",
+        type: "post",
+        data: {
+            itemstatus: itemstatus,
+            id: document.getElementById("current-review-id").value,
+        },
+        headers: {
+            "Authorization": "Basic "+ document.getElementById("token").value
+        },
+        dataType: "json",
+        success: function(data) {
+            // 해당 id의 stage 글씨와 색상을 바꾼다.
+            let itemStatus = document.getElementById("review-itemstatus-"+data.id)
+            itemStatus.innerHTML = data.itemstatus
+            itemStatus.setAttribute("class","ml-1 badge badge-status-"+data.itemstatus)
+            // 현재 띄워진 화면의 우측하단의 Stage 상태를 변경한다.
+            document.getElementById("current-review-itemstatus").value = data.itemstatus
         },
         error: function(request,status,error){
             alert("code:"+request.status+"\n"+"status:"+status+"\n"+"msg:"+request.responseText+"\n"+"error:"+error);

--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -4683,8 +4683,8 @@ function setReviewItemStatus(itemstatus) {
         url: "/api/setreviewitemstatus",
         type: "post",
         data: {
-            itemstatus: itemstatus,
             id: document.getElementById("current-review-id").value,
+            itemstatus: itemstatus,
         },
         headers: {
             "Authorization": "Basic "+ document.getElementById("token").value
@@ -4694,7 +4694,7 @@ function setReviewItemStatus(itemstatus) {
             // 해당 id의 stage 글씨와 색상을 바꾼다.
             let itemStatus = document.getElementById("review-itemstatus-"+data.id)
             itemStatus.innerHTML = data.itemstatus
-            itemStatus.setAttribute("class","ml-1 badge badge-status-"+data.itemstatus)
+            itemStatus.setAttribute("class","ml-1 badge badge-"+data.itemstatus)
             // 현재 띄워진 화면의 우측하단의 Stage 상태를 변경한다.
             document.getElementById("current-review-itemstatus").value = data.itemstatus
         },

--- a/assets/template/modal-review-bootstrap5.html
+++ b/assets/template/modal-review-bootstrap5.html
@@ -398,7 +398,7 @@
         </div>
     </div>
 
-    <!-- Modal: Edit Review -->
+    <!-- Modal: Edit Review Stage Mode -->
     <div class="modal" id="modal-editreview" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
         <div class="modal-dialog" role="document">
             <div class="modal-content bg-darkmode">
@@ -449,6 +449,131 @@
                                     {{end}}
                                 </select>
                                 <small>리뷰 Stage 이름</small>
+                            </div>
+                        </div>
+                        <div class="col pt-0 pb-0">
+                            <div class="form-group">
+                                <label class="form-text">Author</label>
+                                <input type="text" class="form-control" id="modal-editreview-author" value="{{.User.ID}}" disabled>
+                                <small>사용자 ID</small>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="form-group">
+                            <label class="form-text">Createtime</label>
+                            <div class="input-group pt-0 m-0 col-12">
+                                <input type="text" class="form-control" placeholder="0000-00-00T00:00:00+09:00" id="modal-editreview-createtime" onchange="setReviewCreatetime()">
+                                <button class="btn btn-darkmode btn-block" onclick="setReviewCreatetimeNow()">Set Now!</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group pt-0 m-0">
+                        <label class="form-text">Path</label>
+                        <input type="text" class="form-control" placeholder="데일리로 올릴 미디어 경로" value="" id="modal-editreview-path" onchange="setReviewPath()">
+                    </div>
+                    <div class="row">
+                        <div class="col-6 form-group">
+                            <label class="form-text">Main Version</label>
+                            <input type="number" value="1" min="1" max="1000" step="1" class="form-control" id="modal-editreview-mainversion" onchange="setReviewMainVersion()">
+                            <small class="form-text text-muted">메인버전을 입력해주세요.</small>
+                        </div>
+                        <div class="col-6 form-group">
+                            <label class="form-text">Sub Version</label>
+                            <input type="number" value="0" min="0" max="1000" step="1" class="form-control" id="modal-editreview-subversion" onchange="setReviewSubVersion()">
+                            <small class="form-text text-muted">서브버전을 입력해주세요.</small>
+                        </div>
+                    </div>
+                    <div class="form-group p-0 m-0">
+                        <label class="form-text">FPS</label>
+                        <select id="modal-editreview-fps" class="form-control" onchange="setReviewFps()">
+                            <option value="24">24</option>
+                            <option value="23.976">23.976</option>
+                            <option value="23.98">23.98</option>
+                            <option value="25">25</option>
+                            <option value="30">30</option>
+                            <option value="29.97">29.97</option>
+                            <option value="59.94">59.94</option>
+                            <option value="60">60</option>
+                        </select>
+                        <small>리뷰 재생시 필요한 fps. 리뷰창에서 프레임을 앞뒤로 움직일때도 사용됩니다.</small>
+                    </div>
+                    <div class="form-group">
+                        <label for="modal-editreview-description" class="col-form-label">Description</label>
+                        <div class="input-group">
+                            <textarea class="form-control" id="modal-editreview-description" rows="2"></textarea>
+                            <button id="modal-editreview-description-button" class="btn btn-sm btn-outline-warning btn-block" onclick="setReviewDescription()">Edit</button>
+                        </div>
+                    </div>
+                    <div class="form-group p-0 m-0">
+                        <label class="form-text">Camera Info</label>
+                        <input type="text" class="form-control" placeholder="camera info" value="" id="modal-editreview-camerainfo" onchange="setReviewCameraInfo()">
+                        <small>카메라 렌즈 미리수 정보처럼 리뷰어의 판단에 영향을 미치는 정보를 기록해 주세요.</small>
+                    </div>
+                    <div class="form-group p-0 m-0">
+                        <label for="modal-editreview-outputdatapath" class="col-form-label">Output Data Path</label>
+                        <input type="text" class="form-control" id="modal-editreview-outputdatapath"  onchange="ReviewOutputDataPath()">
+                        <small class="form-text text-muted">Review 완료되면 외부로 복사해야하는 데이터 경로(Plate, mov, 협업데이터 경로)</small>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-darkmode" data-bs-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal: Edit Review Status Mode -->
+    <div class="modal" id="modal-editreview-statusmode" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content bg-darkmode">
+                <div class="modal-header">
+                <h5 class="modal-title" id="modal-editreview-title">Edit Review</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" class="form-control" id="modal-editreview-id">
+                    <div class="row">
+                        <div class="col-4 pt-0 pb-0">
+                            <div class="form-group">
+                                <label class="form-text">Project</label>
+                                <select id="modal-editreview-project" class="form-control" onchange="setReviewProject()">
+                                    {{range .Projectlist}}
+                                        <option value="{{.}}" {{if eq . $.SearchOption.Project}}selected{{end}}>{{.}}</option>
+                                    {{end}}
+                                </select>
+                                <small>프로젝트 선택</small>
+                            </div>
+                        </div>
+                        <div class="col-8 pt-0 pb-0">
+                            <div class="form-group">
+                                <label class="form-text">Name</label>
+                                <input type="text" class="form-control" id="modal-editreview-name" value="" onchange="setReviewName()">
+                                <small>Shot, Asset 이름</small>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col pt-0 pb-0">
+                            <div class="form-group">
+                                <label class="form-text">Task</label>
+                                <select id="modal-editreview-task" class="form-control" onchange="setReviewTask()">
+                                    {{range .TasksettingNames}}
+                                        <option value="{{.}}" {{if eq $.SearchOption.Task . }}selected{{end}}>{{.}}</option>
+                                    {{end}}
+                                </select>
+                                <small>Task를 선택해주세요.</small>
+                            </div>
+                        </div>
+                        <div class="col pt-0 pb-0">
+                            <div class="form-group">
+                                <label class="form-text">Status</label>
+                                <select class="form-control" id="modal-editreview-itemstatus" onchange="setReviewItemStatus(this.value)">
+                                    {{range .Status}}
+                                        <option value="{{.ID}}">{{.ID}}</option>
+                                    {{end}}
+                                </select>
+                                <small>리뷰 Status Item</small>
                             </div>
                         </div>
                         <div class="col pt-0 pb-0">

--- a/assets/template/modal-review.html
+++ b/assets/template/modal-review.html
@@ -541,4 +541,132 @@
             </div>
         </div>
     </div>
+
+    <!-- Modal: Edit Review Status Mode-->
+    <div class="modal" id="modal-editreview-statusmode" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content bg-darkmode">
+                <div class="modal-header">
+                <h5 class="modal-title" id="modal-editreview-title">Edit Review</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true" class="text-darkmode">&times;</span>
+                </button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" class="form-control" id="modal-editreview-id">
+                    <div class="row">
+                        <div class="col-4 pt-0 pb-0">
+                            <div class="form-group">
+                                <label class="form-text">Project</label>
+                                <select id="modal-editreview-project" class="form-control" onchange="setReviewProject()">
+                                    {{range .Projectlist}}
+                                        <option value="{{.}}" {{if eq . $.SearchOption.Project}}selected{{end}}>{{.}}</option>
+                                    {{end}}
+                                </select>
+                                <small>프로젝트를 선택해주세요.</small>
+                            </div>
+                        </div>
+                        <div class="col-8 pt-0 pb-0">
+                            <div class="form-group">
+                                <label class="form-text">Name</label>
+                                <input type="text" class="form-control" id="modal-editreview-name" value="" onchange="setReviewName()">
+                                <small>Shot, Asset 이름</small>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col pt-0 pb-0">
+                            <div class="form-group">
+                                <label class="form-text">Task</label>
+                                <select id="modal-editreview-task" class="form-control" onchange="setReviewTask()">
+                                    {{range .TasksettingNames}}
+                                        <option value="{{.}}" {{if eq $.SearchOption.Task . }}selected{{end}}>{{.}}</option>
+                                    {{end}}
+                                </select>
+                                <small>Task를 선택해주세요.</small>
+                            </div>
+                        </div>
+                        <div class="col pt-0 pb-0">
+                            <div class="form-group">
+                                <label class="form-text">Status</label>
+                                <select class="form-control" id="modal-editreview-itemstatus" onchange="setReviewItemStatus(this.value)">
+                                    {{range .Status}}
+                                        <option value="{{.ID}}">{{.ID}}</option>
+                                    {{end}}
+                                </select>
+                                <small>리뷰 ItemStatus</small>
+                            </div>
+                        </div>
+                        <div class="col pt-0 pb-0">
+                            <div class="form-group">
+                                <label class="form-text">Author</label>
+                                <input type="text" class="form-control" id="modal-editreview-author" value="{{.User.ID}}" disabled>
+                                <small>사용자 ID</small>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="form-group pt-0 m-0 col-8">
+                            <label class="form-text">Createtime</label>
+                            <input type="text" class="form-control" placeholder="0000-00-00T00:00:00+09:00" id="modal-editreview-createtime" onchange="setReviewCreatetime()">
+                        </div>
+                        <div class="form-group pt-0 m-0 col-4">
+                            <label class="form-text">&nbsp;</label>
+                            <button class="btn btn-darkmode btn-block" onclick="setReviewCreatetimeNow()">Set Now!</button>
+                        </div>
+                    </div>
+                    <div class="form-group pt-0 m-0">
+                        <label class="form-text">Path</label>
+                        <input type="text" class="form-control" placeholder="데일리로 올릴 미디어 경로" value="" id="modal-editreview-path" onchange="setReviewPath()">
+                    </div>
+                    <div class="row">
+                        <div class="col-6 form-group">
+                            <label class="form-text">Main Version</label>
+                            <input type="number" value="1" min="1" max="1000" step="1" class="form-control" id="modal-editreview-mainversion" onchange="setReviewMainVersion()">
+                            <small class="form-text text-muted">메인버전을 입력해주세요.</small>
+                        </div>
+                        <div class="col-6 form-group">
+                            <label class="form-text">Sub Version</label>
+                            <input type="number" value="0" min="0" max="1000" step="1" class="form-control" id="modal-editreview-subversion" onchange="setReviewSubVersion()">
+                            <small class="form-text text-muted">서브버전을 입력해주세요.</small>
+                        </div>
+                    </div>
+                    <div class="form-group p-0 m-0">
+                        <label class="form-text">FPS</label>
+                        <select id="modal-editreview-fps" class="form-control" onchange="setReviewFps()">
+                            <option value="24">24</option>
+                            <option value="23.976">23.976</option>
+                            <option value="23.98">23.98</option>
+                            <option value="25">25</option>
+                            <option value="30">30</option>
+                            <option value="29.97">29.97</option>
+                            <option value="59.94">59.94</option>
+                            <option value="60">60</option>
+                        </select>
+                        <small>리뷰 재생시 필요한 fps. 리뷰창에서 프레임을 앞뒤로 움직일때도 사용됩니다.</small>
+                    </div>
+                    <div class="form-group">
+                        <label for="modal-editreview-description" class="col-form-label">Description</label>
+                        <textarea class="form-control" id="modal-editreview-description" rows="2"></textarea>
+                        <div class="mt-2">
+                            <button id="modal-editreview-description-button" class="btn btn-sm btn-outline-warning btn-block" onclick="setReviewDescription()">Edit</button>
+                        </div>
+                    </div>
+                    <div class="form-group p-0 m-0">
+                        <label class="form-text">Camera Info</label>
+                        <input type="text" class="form-control" placeholder="camera info" value="" id="modal-editreview-camerainfo" onchange="setReviewCameraInfo()">
+                        <small>카메라 렌즈 미리수 정보처럼 리뷰어의 판단에 영향을 미치는 정보를 기록해 주세요.</small>
+                    </div>
+                    <div class="form-group p-0 m-0">
+                        <label for="modal-editreview-outputdatapath" class="col-form-label">Output Data Path</label>
+                        <input type="text" class="form-control" id="modal-editreview-outputdatapath"  onchange="ReviewOutputDataPath()">
+                        <small class="form-text text-muted">Review 완료되면 외부로 복사해야하는 데이터 경로(Plate, mov, 협업데이터 경로)</small>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-darkmode" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
 {{end}}

--- a/assets/template/modal-review.html
+++ b/assets/template/modal-review.html
@@ -414,8 +414,8 @@
         </div>
     </div>
 
-    <!-- Modal: Edit Review -->
-    <div class="modal fade" id="modal-editreview" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <!-- Modal: Edit Review Stage Mode-->
+    <div class="modal" id="modal-editreview" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
         <div class="modal-dialog" role="document">
             <div class="modal-content bg-darkmode">
                 <div class="modal-header">

--- a/assets/template/reviewstatus.html
+++ b/assets/template/reviewstatus.html
@@ -63,7 +63,7 @@
                         </div>
                         <div class="col-1 p-0">
                             <!-- 리뷰 수정버튼 -->
-                            <img src="/assets/img/edit.svg" class="finger" data-bs-toggle="modal" data-bs-target="#modal-editreview" onclick="setEditReviewModal('{{.ID.Hex}}')">
+                            <img src="/assets/img/edit.svg" class="finger" data-bs-toggle="modal" data-bs-target="#modal-editreview-statusmode" onclick="setEditReviewModal('{{.ID.Hex}}')">
                             <!-- 리뷰 삭제버튼 -->
                             <img src="/assets/img/delete.svg" class="finger" data-bs-toggle="modal" data-bs-target="#modal-rmreview" onclick="setRmReviewModal('{{.ID.Hex}}')">
                         </div>                        

--- a/db_review.go
+++ b/db_review.go
@@ -99,6 +99,16 @@ func setReviewPath(session *mgo.Session, id, path string) error {
 	return nil
 }
 
+func setReviewItemStatus(session *mgo.Session, id, itemstatus string) error {
+	session.SetMode(mgo.Monotonic, true)
+	c := session.DB("csi").C("review")
+	err := c.UpdateId(bson.ObjectIdHex(id), bson.M{"$set": bson.M{"itemstatus": itemstatus}})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // setErrReview 함수는 id와 log를 입력받아서 에러상태 변경 및 로그를 기록한다.
 func setErrReview(session *mgo.Session, id, log string) error {
 	session.SetMode(mgo.Monotonic, true)

--- a/handler.go
+++ b/handler.go
@@ -544,6 +544,7 @@ func webserver(port string) {
 	http.HandleFunc("/api/review", handleAPIReview)
 	http.HandleFunc("/api/searchreview", handleAPISearchReview)
 	http.HandleFunc("/api/setreviewstatus", handleAPISetReviewStatus)
+	http.HandleFunc("/api/setreviewitemstatus", handleAPISetReviewItemStatus)
 	http.HandleFunc("/api/setreviewstage", handleAPISetReviewStage)
 	http.HandleFunc("/api/setreviewnextstatus", handleAPISetReviewNextStatus)
 	http.HandleFunc("/api/setreviewnextstage", handleAPISetReviewNextStage)

--- a/restapiReview.go
+++ b/restapiReview.go
@@ -546,6 +546,96 @@ func handleAPISetReviewStatus(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
+// handleAPISetReviewItemStatus 함수는 review의 itemstatus를 설정하는 RestAPI 이다.
+func handleAPISetReviewItemStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Post Only", http.StatusMethodNotAllowed)
+		return
+	}
+	type Recipe struct {
+		UserID     string `json:"userid"`
+		ID         string `json:"id"`
+		ItemStatus string `json:"itemstatus"`
+	}
+	rcp := Recipe{}
+	session, err := mgo.Dial(*flagDBIP)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer session.Close()
+	rcp.UserID, _, err = TokenHandler(r, session)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	r.ParseForm()
+	reviewID := r.FormValue("id")
+	if reviewID == "" {
+		http.Error(w, "id를 설정해주세요", http.StatusBadRequest)
+		return
+	}
+	rcp.ID = reviewID
+
+	itemStatus := r.FormValue("itemstatus")
+	if itemStatus == "" {
+		http.Error(w, "itemstatus를 설정해주세요", http.StatusBadRequest)
+		return
+	}
+	rcp.ItemStatus = itemStatus
+	// Review 데이터를 가지고 온다. 해당정보를 이용해서 Task 정보를 수정할 수 있는 정보를 수집한다.
+	review, err := getReview(session, rcp.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// 리뷰 ItemStatus를 설정한다.
+	err = setReviewItemStatus(session, rcp.ID, itemStatus)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// Type을 구한다.
+	typ, err := Type(session, review.Project, review.Name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// 실제 아이템의 Shot, Asset Status를 설정한다.
+	_, err = SetTaskStatusV2(session, review.Project, review.Name+"_"+typ, review.Task, itemStatus)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// log
+	err = dilog.Add(*flagDBIP, host, fmt.Sprintf("Set Review Item Status: %s, %s", rcp.ID, rcp.ItemStatus), review.Project, review.Name, "csi3", rcp.UserID, 180)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// slack log
+	err = slacklog(session, review.Project, fmt.Sprintf("Set Review Item Status: %s, \nProject: %s, Name: %s, Author: %s", itemStatus, review.Project, review.Name, rcp.UserID))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	data, err := json.Marshal(rcp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	w.Write(data)
+}
+
 // handleAPISetReviewNextStatus 함수는 review의 상태를 설정하는 RestAPI 이다.
 func handleAPISetReviewNextStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {


### PR DESCRIPTION
Close: #1480 

review데이터의 itemstatus 를 수정하면 해당 샷 또는 에셋의 상태가 동시에 수정된다.
<img width="781" alt="2022-01-06_12-34-49" src="https://user-images.githubusercontent.com/1149996/148324324-659d6ab3-b8ed-45e5-b656-76d8b42c2e78.png">
Review Comment 쪽에서도 손쉽게 itemstatus를 변경할 수 있다.
<img width="240" alt="2022-01-06_12-35-09" src="https://user-images.githubusercontent.com/1149996/148324299-0be0cf4b-2913-47b3-9c54-303e8eaea470.png">
값이 바뀌면 실제 샷의 Task Status가 바뀐 모습
<img width="367" alt="2022-01-06_12-35-34" src="https://user-images.githubusercontent.com/1149996/148324290-d657a9ee-21a3-4a1b-8cd4-1d1df411deb0.png">
