### PR TITLE
projecttype요소 옮김

### DIFF
--- a/assets/template/editProject.html
+++ b/assets/template/editProject.html
@@ -81,6 +81,17 @@
 							<small class="form-text text-muted">넷플릭스 Show ID</small>
 							<input type="text" name="NetflixShowID" class="form-control" placeholder="넷플릭스 Show ID" value={{.Project.NetflixShowID}}>
 						</div>
+						<div class="col">
+							<div class="form-group">
+								<label class="pt-1">ProjectType</label>
+								<select class="form-control" id="projectforpartner-projecttype">
+									<option value="" selected>Unknown</option>
+									<option value="A">A</option>
+									<option value="B">B</option>
+									<option value="C">C</option>
+								</select>
+							</div>
+						</div>
 					</div>
 					<div class="row">
 						<div class="col">

--- a/assets/template/modal-projectforpartner.html
+++ b/assets/template/modal-projectforpartner.html
@@ -37,17 +37,6 @@
                             <div class="row">
                                 <div class="col">
                                     <div class="form-group">
-                                        <label class="pt-1">ProjectType</label>
-                                        <select class="form-control" id="projectforpartner-projecttype">
-                                            <option value="" selected>Unknown</option>
-                                            <option value="A">A</option>
-                                            <option value="B">B</option>
-                                            <option value="C">C</option>
-                                        </select>
-                                    </div>
-                                </div>
-                                <div class="col">
-                                    <div class="form-group">
                                         <label class="pt-1">사용언어</label>
                                         <input type="text" class="form-control" id="projectforpartner-language" placeholder="사용언어">
                                     </div>

--- a/struct_partner.go
+++ b/struct_partner.go
@@ -65,29 +65,29 @@ type Moneytype struct {
 
 // ProjectForPartner 자료구조는 프로젝트와 파트너사이의 관계를 다루는 자료구조
 type ProjectForPartner struct {
-	ID                      primitive.ObjectID `bson:"_id" json:"id,omitempty"`
-	ProjectName             string             `json:"projectname"`             // 프로젝트 이름
-	PartnerName             string             `json:"partnername"`             // 파트너이름
-	RNR                     string             `json:"rnr"`                     // 계약,진행상태
-	ProjectBudget           float64            `json:"projectbudget"`           // 프로젝트 비용
-	ProjectType             string             `json:"projecttype"`             // 프로젝트 타입, 타입설정, "A","B","C"
-	StartDate               string             `json:"startdate"`               // 프로젝트 시작일
-	EndDate                 string             `json:"enddate"`                 // 프로젝트 완료일
-	PercentageOfTotalBudget float64            `json:"percentageoftotalbudget"` // 나가는 비용이 프로젝트 총 비용의 몇 퍼센트인가?
-	Description             string             `json:"description"`             // 외주내용
-	PricePerShot            float64            `json:"pricepershot"`            // 컷당 가격
-	PricePerFrame           float64            `json:"priceperframe"`           // 프레임당 가격
-	PartnerInternalManager  string             `json:"partnerinternalmanager"`  // 파트너 내부관리자
-	ManagerEmail            string             `json:"manageremail"`            // 파트너 내부관리자 메일
-	PaymentCycle            string             `json:"paymentcycle"`            // 지급회차 1/2, 4/6: 현재 지급단계, 총 지급횟수
-	PaymentDateForClient    int                `json:"paymentdateforclient"`    // 클라이언트에게 돈을 받는날짜, 프로젝트(프로젝트 월별 지급일)
-	PaymentDateForVender    int                `json:"paymentdateforvender"`    // 벤더에게 주는 날짜, 프로젝트 진행시 벤더에게 돈을 주는 날짜
-	Language                string             `json:"language"`                // 사용언어: 커뮤니케이션 언어
-	Messenger               string             `json:"messenger"`               // 사용 메신저 종류
-	MessengerID             string             `json:"messengerid"`             // 메신저 ID
-	Manday                  int                `json:"manday"`                  // 예상 맨데이, 회계 작성시 필요, 감사시 필요
-	LeftoverShot            int                `json:"leftovershot"`            // 남은컷
-	TotalShot               int                `json:"totalshot"`               // 총컷
+	ID            primitive.ObjectID `bson:"_id" json:"id,omitempty"`
+	ProjectName   string             `json:"projectname"`   // 프로젝트 이름
+	PartnerName   string             `json:"partnername"`   // 파트너이름
+	RNR           string             `json:"rnr"`           // 계약,진행상태
+	ProjectBudget float64            `json:"projectbudget"` // 프로젝트 비용
+
+	StartDate               string  `json:"startdate"`               // 프로젝트 시작일
+	EndDate                 string  `json:"enddate"`                 // 프로젝트 완료일
+	PercentageOfTotalBudget float64 `json:"percentageoftotalbudget"` // 나가는 비용이 프로젝트 총 비용의 몇 퍼센트인가?
+	Description             string  `json:"description"`             // 외주내용
+	PricePerShot            float64 `json:"pricepershot"`            // 컷당 가격
+	PricePerFrame           float64 `json:"priceperframe"`           // 프레임당 가격
+	PartnerInternalManager  string  `json:"partnerinternalmanager"`  // 파트너 내부관리자
+	ManagerEmail            string  `json:"manageremail"`            // 파트너 내부관리자 메일
+	PaymentCycle            string  `json:"paymentcycle"`            // 지급회차 1/2, 4/6: 현재 지급단계, 총 지급횟수
+	PaymentDateForClient    int     `json:"paymentdateforclient"`    // 클라이언트에게 돈을 받는날짜, 프로젝트(프로젝트 월별 지급일)
+	PaymentDateForVender    int     `json:"paymentdateforvender"`    // 벤더에게 주는 날짜, 프로젝트 진행시 벤더에게 돈을 주는 날짜
+	Language                string  `json:"language"`                // 사용언어: 커뮤니케이션 언어
+	Messenger               string  `json:"messenger"`               // 사용 메신저 종류
+	MessengerID             string  `json:"messengerid"`             // 메신저 ID
+	Manday                  int     `json:"manday"`                  // 예상 맨데이, 회계 작성시 필요, 감사시 필요
+	LeftoverShot            int     `json:"leftovershot"`            // 남은컷
+	TotalShot               int     `json:"totalshot"`               // 총컷
 }
 
 type PartnerEvent struct {

--- a/struct_project.go
+++ b/struct_project.go
@@ -43,6 +43,7 @@ type Project struct {
 	ID                       string        `json:"id"`                       // 프로젝트 ID
 	NetflixShowID            string        `json:"netflixshowid"`            // 넷플릭스 Show ID
 	Name                     string        `json:"name"`                     // 프로젝트 한글이름
+	ProjectType              string        `json:"projecttype"`              // 프로젝트 타입, 타입설정, "A","B","C"
 	MailHead                 string        `json:"mailhead"`                 // 이메일헤드 "[부산행]"
 	Style                    string        `json:"style"`                    // 영화, 에니메이션, 광고, VR
 	Stereo                   bool          `json:"stereo"`                   // 입체 프로젝트


### PR DESCRIPTION
- 파트너관련 프로젝트 설정에 있던 프로젝트 타입을 기본 프로젝트 정보로 옮기기 위해서 필요한 절차이다.
- [ ] editprojec_submmit 에 DB 저장항목을 추가해야한다.